### PR TITLE
Can't remove last tag because of "if ($this->value)" check.

### DIFF
--- a/code/TagField.php
+++ b/code/TagField.php
@@ -168,15 +168,13 @@ class TagField extends TextField {
 	}
 	
 	function saveInto($record) {		
-		if($this->value) {
-			// $record should match the $tagTopicClass
-			if($record->many_many($this->Name())) {
-				$this->saveIntoObjectTags($record);
-			} elseif($record->hasField($this->Name())) {
-				$this->saveIntoTextbasedTags($record);
-			} else {
-				user_error('TagField::saveInto(): Cant find valid field or relation to save into', E_USER_ERROR);
-			}
+		// $record should match the $tagTopicClass
+		if($record->many_many($this->Name())) {
+			$this->saveIntoObjectTags($record);
+		} elseif($record->hasField($this->Name())) {
+			$this->saveIntoTextbasedTags($record);
+		} else {
+			user_error('TagField::saveInto(): Cant find valid field or relation to save into', E_USER_ERROR);
 		}
 	}
 	


### PR DESCRIPTION
This occurs using comma as a separator, and the only way to remove all tags from the field is to use a single comma.  This isn't very intuitive.  I suggest dropping the check as shown in this pull request.
