### PR TITLE
Destory chosen when hidden elements are shown

### DIFF
--- a/js/TagField.js
+++ b/js/TagField.js
@@ -10,7 +10,6 @@
 	 */
 	$.fn.chosenDestroy = function () {
 		$(this)
-			.show()
 			.removeClass('chzn-done')
 			.removeClass('has-chzn')
 			.next()
@@ -21,31 +20,27 @@
 
 	$.entwine('ss', function($) {
 
-		$('.silverstripe-tag-field').entwine({
-			'onadd': function() {
-				var $this = $(this);
+		$('.silverstripe-tag-field + .chzn-container').entwine({
+			onmatch: function() {
+				var $select = $(this).prev();
+
+				$select
+					.chosenDestroy()
+					.select2({
+						'tags': true,
+						'tokenSeparators': [',', ' ']
+					});
 
 				/*
-				 * Delay a cycle so we don't see 2 inputs...
+				 * Delay a cycle so select2 is initialised before
+				 * selecting values (if data-selected-values is present).
 				 */
 				setTimeout(function () {
-					$this.chosenDestroy()
-						.select2({
-							'tags': true,
-							'tokenSeparators': [',', ' ']
-						});
+					if ($select.attr('data-selected-values')) {
+						var values = $select.attr('data-selected-values');
 
-					/*
-					 * Delay a cycle so select2 is initialised before
-					 * selecting values (if data-selected-values is present).
-					 */
-					setTimeout(function () {
-						if ($this.attr('data-selected-values')) {
-							var values = $this.attr('data-selected-values');
-
-							$this.select2('val', values.split(','));
-						}
-					}, 0);
+						$select.select2('val', values.split(','));
+					}
 				}, 0);
 			}
 		});


### PR DESCRIPTION
This fixes an issue where hidden `select` elements are not handled correctly, resulting in Chosen not being destroyed.

Here's a screenshot of the bug...
![loaded-with-sidebar-closed](https://cloud.githubusercontent.com/assets/878176/7243797/52253d1a-e826-11e4-948f-6342c18e4a46.png)

Notice there are two fields under the 'Categories' and 'Tags' labels.

To reproduce this the page needs to be reloaded with the sidebar collapsed (`select` elements not visible). After the page has reloaded, expand the sidebar, and you see the above screenshot.

This happens because TagField assumes Chosen functionality is added when the field is created. However - [Chosen is applied when the field is made visible](https://github.com/silverstripe/silverstripe-framework/blob/3.1/admin/javascript/LeftAndMain.js#L76), so [destroying chosen using a timeout inside an `onadd`](https://github.com/silverstripe-labs/silverstripe-tagfield/blob/develop/js/TagField.js#L31) only works if the field is visible when the page is loaded.

So what's happen at the moment is:
- The page loads with the field hidden.
- TagField attempts to destroy Chosen (which has not been applied yet because the field is hidden) and applies Select2.
- The field is made visible by expanding the sidebar.
- Chosen is applied to the field.

Here's how the fix works...
The selector has changed to `.silverstripe-tag-field + .chzn-container`. This guarantees we're dealing with a field that Chosen has been applied to, removing the need for the first `setTimeout`. I'm selecting the container rather than the field because the field is hidden at this point, so `onmatch` wouldn't fire.

I have also removed the `.show()` inside the `chosenDestroy` function so you don't get a flash of the unstyled `select` element.