### PR TITLE
Update TagField.js so tags with spaces can be added

### DIFF
--- a/js/TagField.js
+++ b/js/TagField.js
@@ -37,7 +37,7 @@
 
 				var options = {
 					'tags': true,
-					'tokenSeparators': [',', ' ']
+					'tokenSeparators': [',']
 				};
 
 				if ($select.attr('data-ss-tag-field-suggest-url')) {


### PR DESCRIPTION
The separator is hard coded as space or comma.  Not much is lost if you just delete the space separator option.  This allows people to add eg "Web Developer" as a job title tag.