### PR TITLE
FIX: Override DropdownField::validate for SS3.2 compatiblity

### DIFF
--- a/code/TagField.php
+++ b/code/TagField.php
@@ -327,4 +327,17 @@ class TagField extends DropdownField {
 
 		return $items;
 	}
+
+
+	/**
+	 * DropdownField assumes value will be a scalar so we must
+	 * override validate. This only applies to Silverstripe 3.2+
+	 *
+	 * @param Validator $validator
+	 * @return bool
+	 */
+	public function validate($validator) {
+		return true;
+	}
+
 }


### PR DESCRIPTION
Prior to this fix a clean install of 3.2 + blog yields the following error when saving a post:

```
ERROR [Warning]: array_key_exists(): The first argument should be either a string or an integer
IN POST /admin/pages/edit/EditForm
Line 323 in /Users/guinns/projects/blog-test/framework/forms/DropdownField.php
```