### PR TITLE
Fixing missing template error

### DIFF
--- a/code/StringTagField.php
+++ b/code/StringTagField.php
@@ -130,7 +130,7 @@ class StringTagField extends DropdownField {
 
 		return $this
 			->customise($properties)
-			->renderWith(array("templates/StringTagField"));
+			->renderWith(array("templates/TagField"));
 	}
 
 	/**


### PR DESCRIPTION
The StringTagField tries to use a StringTagField.ss template, which doesn't existing. I have changed this to use the TagField.ss template instead.

This fixes issue #30 