### PR TITLE
Fixed issue where empty keywords field would be passed to array functions as a string

### DIFF
--- a/code/StringTagField.php
+++ b/code/StringTagField.php
@@ -177,7 +177,7 @@ class StringTagField extends DropdownField {
 
 		if($source instanceof DataObject) {
 			$name = $this->getName();
-			$value = $source->$name;
+			$value = explode(',', $source->$name);
 		}
 
 		if($source instanceof SS_List) {


### PR DESCRIPTION
Fix for issue #37.