### PR TITLE
BUGFIX: Fixed notice from array_filter when the value is null

### DIFF
--- a/code/TagField.php
+++ b/code/TagField.php
@@ -207,6 +207,10 @@ class TagField extends DropdownField {
 			$value = $value->column('ID');
 		}
 
+		if(!is_array($value)) {
+			return parent::setValue($value);
+		}
+
 		return parent::setValue(array_filter($value));
 	}
 


### PR DESCRIPTION
In cases where the value of the tag field is null a notice is thrown (see bellow) this pull hands off to DropdownField's setValue() when the value is not an array.

```
array_filter() expects parameter 1 to be array, null given tagfield/code/TagField.php:210
```