### PR TITLE
Added option to disable multiple selections.

### DIFF
--- a/code/StringTagField.php
+++ b/code/StringTagField.php
@@ -78,6 +78,24 @@ class StringTagField extends DropdownField {
 		return $this;
 	}
 
+    /**
+	 * @return bool
+	 */
+	public function getIsMultiple() {
+		return $this->isMultiple;
+	}
+
+	/**
+	 * @param bool $isMultiple
+	 *
+	 * @return static
+	 */
+	public function setIsMultiple($isMultiple) {
+		$this->isMultiple = $isMultiple;
+
+		return $this;
+	}
+
 	/**
 	 * @return null|DataObject
 	 */
@@ -119,6 +137,10 @@ class StringTagField extends DropdownField {
 		$this->addExtraClass('ss-tag-field');
 
 		$this->setAttribute('multiple', 'multiple');
+
+        if ($this->getIsMultiple()) {
+		    $this->setAttribute('multiple', 'multiple');
+        }
 
 		if($this->getShouldLazyLoad()) {
 			$this->setAttribute('data-ss-tag-field-suggest-url', $this->getSuggestURL());
@@ -282,7 +304,7 @@ class StringTagField extends DropdownField {
 
 		return $items;
 	}
-	
+
 	/**
 	 * DropdownField assumes value will be a scalar so we must
 	 * override validate. This only applies to Silverstripe 3.2+

--- a/code/TagField.php
+++ b/code/TagField.php
@@ -80,6 +80,24 @@ class TagField extends DropdownField {
 		return $this;
 	}
 
+    /**
+	 * @return bool
+	 */
+	public function getIsMultiple() {
+		return $this->isMultiple;
+	}
+
+	/**
+	 * @param bool $isMultiple
+	 *
+	 * @return static
+	 */
+	public function setIsMultiple($isMultiple) {
+		$this->isMultiple = $isMultiple;
+
+		return $this;
+	}
+
 	/**
 	 * @return bool
 	 */
@@ -130,7 +148,9 @@ class TagField extends DropdownField {
 
 		$this->addExtraClass('ss-tag-field');
 
-		$this->setAttribute('multiple', 'multiple');
+        if ($this->getIsMultiple()) {
+		    $this->setAttribute('multiple', 'multiple');
+        }
 
 		if($this->shouldLazyLoad) {
 			$this->setAttribute('data-ss-tag-field-suggest-url', $this->getSuggestURL());


### PR DESCRIPTION
Added option to disable multiple selections.

E.g. 
```php
StringTagField::create()->setIsMultiple(false)
```

This combined with `->setAttribute("data-multiple", 0)` makes it work like a standard select box but with search.