### PR TITLE
Fixing setValue null value bug

### DIFF
--- a/code/StringTagField.php
+++ b/code/StringTagField.php
@@ -223,6 +223,10 @@ class StringTagField extends DropdownField
             $value = $source->column('ID');
         }
 
+        if (is_null($value)) {
+            $value = array();
+        }
+
         return parent::setValue(array_filter($value));
     }
 


### PR DESCRIPTION
On rare occasions when a form is submitted `StringTagField` throws the following error at the end of the `setValue` function: 

    ERROR [Warning]: array_filter() expects parameter 1 to be array, null given

I have added some code that checks if `$value` is `null`. If it is `null` it sets `$value` to an empty array to prevent the error from occurring.