### PR TITLE
Addition of a readonly TagField for archived pages

### DIFF
--- a/code/TagField.php
+++ b/code/TagField.php
@@ -448,7 +448,6 @@ class TagField_Readonly extends TagField
         
         $field->setForm($this->form);
         $field->setValue(implode(', ', $options));
-        
         return $field->Field();
     }
 }

--- a/code/TagField.php
+++ b/code/TagField.php
@@ -415,7 +415,7 @@ class TagField extends DropdownField
     public function performReadonlyTransformation()
     {
         $copy = $this->castedCopy('TagField_Readonly');
-        
+        $copy->setSource($this->getSource());
         return $copy;
     }
 }
@@ -431,7 +431,7 @@ class TagField_Readonly extends TagField
     protected $readonly = true;
     
     /**
-     * Render the field as HTML.
+     * Render the readonly field as HTML.
      *
      * @param array $properties
      * @return HTMLText
@@ -440,7 +440,7 @@ class TagField_Readonly extends TagField
     {
         $options = array();
         
-        foreach ($this->getOptions() as $option) {
+        foreach ($this->getOptions()->filter('Selected', true) as $option) {
             $options[] = $option->Title;
         }
         

--- a/code/TagField.php
+++ b/code/TagField.php
@@ -406,4 +406,49 @@ class TagField extends DropdownField
     {
         return true;
     }
+    
+    /**
+     * Converts the field to a readonly variant.
+     *
+     * @return TagField_Readonly
+     */
+    public function performReadonlyTransformation()
+    {
+        $copy = $this->castedCopy('TagField_Readonly');
+        
+        return $copy;
+    }
+}
+
+/**
+ * A readonly extension of TagField useful for non-editable items within the CMS.
+ *
+ * @package forms
+ * @subpackage fields
+ */
+class TagField_Readonly extends TagField
+{
+    protected $readonly = true;
+    
+    /**
+     * Render the field as HTML.
+     *
+     * @param array $properties
+     * @return HTMLText
+     */
+    public function Field($properties = array())
+    {
+        $options = array();
+        
+        foreach ($this->getOptions() as $option) {
+            $options[] = $option->Title;
+        }
+        
+        $field = ReadonlyField::create($this->name.'_Readonly', $this->title);
+        
+        $field->setForm($this->form);
+        $field->setValue(implode(', ', $options));
+        
+        return $field->Field();
+    }
 }


### PR DESCRIPTION
Howdy! I noticed that if a TagField is present in the CMS fields for a page, and that page is archived, the code errors when a performReadonlyTransformation() is called on the field, due to "array to string conversion". It's an error originating in DropdownField->Field(), as it's expecting a string value for the field and not an array.

In this PR, I've fixed it by adding a TagField_Readonly subclass and a performReadonlyTransformation() override on TagField.  It will render a labelled ReadonlyField with a comma-separated string of the tags associated with the archived page.  :thumbsup: