### PR TITLE
Fix lazy tags

### DIFF
--- a/src/TagField.php
+++ b/src/TagField.php
@@ -216,7 +216,7 @@ class TagField extends DropdownField
             $this->setAttribute('multiple', 'multiple');
         }
 
-        if ($this->shouldLazyLoad) {
+        if ($this->getShouldLazyLoad()) {
             $this->setAttribute('data-ss-tag-field-suggest-url', $this->getSuggestURL());
         } else {
             $properties = array_merge($properties, array(
@@ -268,7 +268,7 @@ class TagField extends DropdownField
 
         $titleField = $this->getTitleField();
         
-        if ($this->shouldLazyLoad) {
+        if ($this->getShouldLazyLoad()) {
             // only render options that are selected as everything else should be lazy loaded, and or loaded by the form
             foreach ($values as $value) {
                 $options->push(


### PR DESCRIPTION
Added extra semver fixes to https://github.com/silverstripe/silverstripe-tagfield/pull/116. Now setSource() is supported and can be used to populate getSourceList().

There were a couple coding issues I cleaned up at the same time. E.g. if getSourceList() is empty it'll crash less. We should leave this empty if the original list is an array (and thus not a List we can lazy evaluate).

Strictly this field doesn't support array source, but it's a challenge to hard-reject arrays it without breaking semver.