### PR TITLE
Add custom readonly field for StringTagField

### DIFF
--- a/src/ReadonlyStringTagField.php
+++ b/src/ReadonlyStringTagField.php
@@ -15,6 +15,32 @@ use SilverStripe\Forms\SingleLookupField;
 class ReadonlyStringTagField extends SingleLookupField
 {
     /**
+     * Generate a string to load into thie readonly field's value
+     *
+     * @return string
+     */
+    public function getFieldValue()
+    {
+        if (!is_array($this->value)) {
+            $value_array = [$this->value];
+        } else {
+            $value_array = $this->value;
+        }
+
+        $source = $this->getSource();
+        $source = ($source instanceof Map) ? $source->toArray() : $source;
+        $return = [];
+
+        foreach ($value_array as $value) {
+            if (in_array($value, $source)) {
+                $return[] = $value;
+            }
+        }
+
+        return implode(', ', $return);
+    }
+
+    /**
      * Render the readonly field as HTML.
      *
      * @param array $properties
@@ -22,20 +48,9 @@ class ReadonlyStringTagField extends SingleLookupField
      */
     public function Field($properties = array())
     {
-        $value_array = $this->value;
-        $source = $this->getSource();
-        $source = ($source instanceof Map) ? $source->toArray() : $source;
-        $return = [];
-
-        foreach ($value_array as $key => $value) {
-            if (in_array($value, $source)) {
-                $return[] = $value;
-            }
-        }
-
         $field = ReadonlyField::create($this->name . '_Readonly', $this->title);
         $field->setForm($this->form);
-        $field->setValue(implode(', ', $return));
+        $field->setValue($this->getFieldValue());
 
         return $field->Field();
     }

--- a/src/ReadonlyStringTagField.php
+++ b/src/ReadonlyStringTagField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\TagField;
+
+use SilverStripe\ORM\Map;
+use SilverStripe\Forms\ReadonlyField;
+use SilverStripe\Forms\SingleLookupField;
+
+/**
+ * A readonly extension of StringTagField useful for non-editable items within the CMS.
+ *
+ * @package forms
+ * @subpackage fields
+ */
+class ReadonlyStringTagField extends SingleLookupField
+{
+    /**
+     * Render the readonly field as HTML.
+     *
+     * @param array $properties
+     * @return HTMLText
+     */
+    public function Field($properties = array())
+    {
+        $value_array = $this->value;
+        $source = $this->getSource();
+        $source = ($source instanceof Map) ? $source->toArray() : $source;
+        $return = [];
+
+        foreach ($value_array as $key => $value) {
+            if (in_array($value, $source)) {
+                $return[] = $value;
+            }
+        }
+
+        $field = ReadonlyField::create($this->name . '_Readonly', $this->title);
+        $field->setForm($this->form);
+        $field->setValue(implode(', ', $return));
+
+        return $field->Field();
+    }
+}

--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -368,6 +368,7 @@ class StringTagField extends DropdownField
     {
         /** @var ReadonlyTagField $copy */
         $copy = $this->castedCopy(ReadonlyStringTagField::class);
+        $copy->setSource($this->getSource());
         return $copy;
     }
 

--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -360,6 +360,18 @@ class StringTagField extends DropdownField
     }
 
     /**
+     * Converts the field to a readonly variant.
+     *
+     * @return ReadonlyTagField
+     */
+    public function performReadonlyTransformation()
+    {
+        /** @var ReadonlyTagField $copy */
+        $copy = $this->castedCopy(ReadonlyStringTagField::class);
+        return $copy;
+    }
+
+    /**
      * @return bool
      */
     public function getCanCreate()

--- a/tests/StringTagFieldTest.php
+++ b/tests/StringTagFieldTest.php
@@ -133,5 +133,22 @@ class StringTagFieldTest extends SapphireTest
 
         $readOnlyField = $field->performReadonlyTransformation();
         $this->assertEquals(ReadonlyStringTagField::class, get_class($readOnlyField));
+        $this->assertEquals('', $readOnlyField->Value());
+
+        $field_two = new StringTagField('Tags');
+        $field_two->setSource(['Test1', 'Test2', 'Test3']);
+
+        $field_two->setValue(['Test1', 'Test2']);
+        $field_two_readonly = $field_two->performReadonlyTransformation();
+        $this->assertEquals('Test1, Test2', $field_two_readonly->getFieldValue());
+
+        // Ensure an invalid value isn't rendered
+        $field_two->setValue(['Test', 'Test1']);
+        $field_two_readonly = $field_two->performReadonlyTransformation();
+        $this->assertEquals('Test1', $field_two_readonly->getFieldValue());
+
+        $field_two->setValue(['Test2']);
+        $field_two_readonly = $field_two->performReadonlyTransformation();
+        $this->assertEquals('Test2', $field_two_readonly->getFieldValue());
     }
 }

--- a/tests/StringTagFieldTest.php
+++ b/tests/StringTagFieldTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\TagField\Tests;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\TagField\ReadonlyStringTagField;
 use SilverStripe\TagField\StringTagField;
 use SilverStripe\TagField\Tests\Stub\StringTagFieldTestBlogPost;
 
@@ -119,5 +120,18 @@ class StringTagFieldTest extends SapphireTest
             'StringTagFieldTestController/StringTagFieldTestForm/fields/Tags/suggest',
             $parameters
         );
+    }
+
+    /**
+     * Test read only fields are returned
+     */
+    public function testReadonlyTransformation()
+    {
+        $record = $this->getNewStringTagFieldTestBlogPost('BlogPost2');
+        $field = new StringTagField('Tags');
+        $field->setRecord($record);
+
+        $readOnlyField = $field->performReadonlyTransformation();
+        $this->assertEquals(ReadonlyStringTagField::class, get_class($readOnlyField));
     }
 }


### PR DESCRIPTION
If I try to view `StringTagField` as a `ReadonlyField`, I get the warning:

```
[Warning] array_key_exists(): The first argument should be either a string or an integer
GET /site/public/admin/messages/App-Model-Message/EditForm/field/App-Model-Message/item/3/view

Line 32 in /path/to/site/vendor/silverstripe/framework/src/Forms/SingleLookupField.php
Source

23     /**
24      * @return mixed|null
25      */
26     protected function valueToLabel()
27     {
28         $value = $this->value;
29         $source = $this->getSource();
30         $source = ($source instanceof Map) ? $source->toArray() : $source;
31 
32         if (array_key_exists($value, $source)) {
33             return $source[$value];
34         }
35 
36         return null;
37     }
38 
```

This is because `SingleLookupField` expects value to be a string or int, not an array.

This PR adds an alternate `ReadOnlyField`, that renders the value into the `ReadonlyField` as a comma separated string (as `ReadonlyTagField`). 

## Issue
- https://github.com/silverstripe/silverstripe-tagfield/issues/232