### PR TITLE
FIX: Fix readonly transformation of field with setTitleField()

### DIFF
--- a/src/TagField.php
+++ b/src/TagField.php
@@ -525,6 +525,8 @@ class TagField extends MultiSelectField
         /** @var ReadonlyTagField $copy */
         $copy = $this->castedCopy(ReadonlyTagField::class);
         $copy->setSourceList($this->getSourceList());
+        $copy->setTitleField($this->getTitleField());
+
         return $copy;
     }
 

--- a/tests/TagFieldTest.php
+++ b/tests/TagFieldTest.php
@@ -352,6 +352,12 @@ class TagFieldTest extends SapphireTest
         $field = new TagField('Tags', '', TagFieldTestBlogTag::get());
         $readOnlyField = $field->performReadonlyTransformation();
         $this->assertInstanceOf(ReadonlyTagField::class, $readOnlyField);
+
+        // Custom title field
+        $field = new TagField('Tags', '', TagFieldTestBlogTag::get());
+        $field->setTitleField('Name');
+        $readOnlyField = $field->performReadonlyTransformation();
+        $this->assertEquals('Name', $readOnlyField->getTitleField());
     }
 
     public function testGetSchemaDataDefaults()


### PR DESCRIPTION
If the title field was customised, this metadata was lost during a
readonly transformation. This can cause fatal errors in read-only views
such as history browsing.