### PR TITLE
BUG Fix field not working in react (asset-admin / elemental)

### DIFF
--- a/src/TagField.php
+++ b/src/TagField.php
@@ -6,7 +6,6 @@ use Exception;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\MultiSelectField;
 use SilverStripe\Forms\Validator;
@@ -317,6 +316,14 @@ class TagField extends MultiSelectField
 
         if (!is_array($value)) {
             return parent::setValue($value);
+        }
+
+        // Safely map php / react-select values to flat list
+        $values = [];
+        foreach ($value as $item) {
+            if ($item) {
+                $values[] = $item['Value'] ?? $item;
+            }
         }
 
         return parent::setValue(array_filter($value));

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -326,7 +326,7 @@ class TagField extends MultiSelectField
             }
         }
 
-        return parent::setValue(array_filter($value));
+        return parent::setValue($values);
     }
 
     /**

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -322,7 +322,7 @@ class TagField extends MultiSelectField
         $values = [];
         foreach ($value as $item) {
             if ($item) {
-                $values[] = $item['Value'] ?? $item;
+                $values[] = isset($item['Value']) ? $item['Value'] : $item;
             }
         }
 

--- a/tests/TagFieldTest.php
+++ b/tests/TagFieldTest.php
@@ -131,6 +131,30 @@ class TagFieldTest extends SapphireTest
             $record
         );
     }
+    
+    public function testSavesReactTags()
+    {
+        $record = $this->getNewTagFieldTestBlogPost('BlogPost1');
+        $record->write();
+
+        $field = new TagField('Tags', '', new DataList(TagFieldTestBlogTag::class));
+        $field->setValue([
+            [
+                'Title' => 'Tag1',
+                'Value' => 'Tag1',
+            ],
+            [
+                'Title' => 'Tag2',
+                'Value' => 'Tag2',
+            ],
+        ]);
+        $field->saveInto($record);
+
+        $this->compareExpectedAndActualTags(
+            ['Tag1', 'Tag2'],
+            $record
+        );
+    }
 
     /**
      * Ensure that {@see TagField::saveInto} respects existing tags


### PR DESCRIPTION
Fixes #150

The issue is to do with the way that react serialises selected values.

I've actually tested this in elemental module, which uses react forms, but it should also fix asset-admin fields.