### PR TITLE
Fix for #171 - Issue when utilizing multiple of same parent class

### DIFF
--- a/src/TagField.php
+++ b/src/TagField.php
@@ -276,8 +276,12 @@ class TagField extends MultiSelectField
         // Convert an array of values into a datalist of options
         if (!$values instanceof SS_List) {
             if (is_array($values) && !empty($values)) {
-                $values = DataList::create($dataClass)
-                    ->filter($this->getTitleField(), $values);
+                if(is_subclass_of($source, DataList::class) || is_a($source, DataList::class)){
+                    $values = $source->filter($this->getTitleField(), $values);
+                } else {
+                    $values = DataList::create($dataClass)
+                        ->filter($this->getTitleField(), $values);
+                }
             } else {
                 $values = ArrayList::create();
             }

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -276,7 +276,7 @@ class TagField extends MultiSelectField
         // Convert an array of values into a datalist of options
         if (!$values instanceof SS_List) {
             if (is_array($values) && !empty($values)) {
-                if (is_subclass_of($source, DataList::class) || is_a($source, DataList::class)) {
+                if (is_a($source, DataList::class)) {
                     $values = $source->filter($this->getTitleField(), $values);
                 } else {
                     $values = DataList::create($dataClass)

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -276,7 +276,7 @@ class TagField extends MultiSelectField
         // Convert an array of values into a datalist of options
         if (!$values instanceof SS_List) {
             if (is_array($values) && !empty($values)) {
-                if(is_subclass_of($source, DataList::class) || is_a($source, DataList::class)){
+                if (is_subclass_of($source, DataList::class) || is_a($source, DataList::class)) {
                     $values = $source->filter($this->getTitleField(), $values);
                 } else {
                     $values = DataList::create($dataClass)


### PR DESCRIPTION
This fix should take care of https://github.com/silverstripe/silverstripe-tagfield/issues/171

Essentially checking first if the source is a datalist of some sort, if so utilize it instead of creating a new one.