### PR TITLE
Make the write call of StringTagField::saveInto method configurable

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -7,9 +7,3 @@ SilverStripe\Admin\LeftAndMain:
     - 'silverstripe/tagfield:client/dist/js/bundle.js'
   extra_requirements_css:
     - 'silverstripe/tagfield:client/dist/styles/bundle.css'
-
----
-Name: tagfieldconfig
----
-SilverStripe\TagField\StringTagField:
-  immediate_write_enabled: true

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -7,3 +7,9 @@ SilverStripe\Admin\LeftAndMain:
     - 'silverstripe/tagfield:client/dist/js/bundle.js'
   extra_requirements_css:
     - 'silverstripe/tagfield:client/dist/styles/bundle.css'
+
+---
+Name: tagfieldconfig
+---
+SilverStripe\TagField\StringTagField:
+  immediate_write_enabled: true

--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -273,7 +273,10 @@ class StringTagField extends DropdownField
         $name = $this->getName();
 
         $record->$name = $this->dataValue();
-        $record->write();
+
+        if (self::config()->get('immediate_write_enabled')) {
+            $record->write();
+        }
     }
 
     /**

--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -34,6 +34,13 @@ class StringTagField extends DropdownField
     ];
 
     /**
+     * @var bool Triggers a write call within the saveInto function if enabled
+     *
+     * @deprecated 3.0.0
+     */
+    private static $immediate_write_enabled = true;
+
+    /**
      * @var bool
      */
     protected $shouldLazyLoad = false;

--- a/tests/StringTagFieldTest.php
+++ b/tests/StringTagFieldTest.php
@@ -61,6 +61,38 @@ class StringTagFieldTest extends SapphireTest
         $this->assertEquals('Tag1,Tag2', $record->Tags);
     }
 
+    public function testImmediateWriteEnabled()
+    {
+        $record = $this->getNewStringTagFieldTestBlogPost('BlogPost1');
+        $record->write();
+
+        StringTagField::config()->update('immediate_write_enabled', true);
+
+        $field = new StringTagField('Tags');
+        $field->setValue(['Tag1', 'Tag2']);
+        $field->saveInto($record);
+
+        $this->assertEquals('Tag1,Tag2', StringTagFieldTestBlogPost::get()->byID($record->ID)->Tags);
+    }
+
+    public function testImmediateWriteDisabled()
+    {
+        $record = $this->getNewStringTagFieldTestBlogPost('BlogPost1');
+        $record->write();
+
+        StringTagField::config()->update('immediate_write_enabled', false);
+
+        $field = new StringTagField('Tags');
+        $field->setValue(['Tag1', 'Tag2']);
+        $field->saveInto($record);
+
+        $this->assertNull(StringTagFieldTestBlogPost::get()->byID($record->ID)->Tags);
+
+        $record->write();
+
+        $this->assertEquals('Tag1,Tag2', StringTagFieldTestBlogPost::get()->byID($record->ID)->Tags);
+    }
+
     public function testItSuggestsTags()
     {
         $field = new StringTagField('SomeField', 'Some field', ['Tag1', 'Tag2'], []);


### PR DESCRIPTION
With that PR its possible to opt-out of the immediate write call within the `saveInto` method of the `StringTagField` using a custom config like this:

```yml
---
Name: app-tagfieldconfig
After:
  - tagfieldconfig
---
SilverStripe\TagField\StringTagField:
  immediate_write_enabled: false
```
