### PR TITLE
add performReadonlyTransformation

### DIFF
--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -412,4 +412,11 @@ class StringTagField extends DropdownField
 
         return $this;
     }
+
+    public function performReadonlyTransformation()
+    {
+        $field = parent::performReadonlyTransformation();
+        $field->setValue(implode(', ', $this->Value()));
+        return $field;
+    }
 }

--- a/tests/StringTagFieldTest.php
+++ b/tests/StringTagFieldTest.php
@@ -171,22 +171,26 @@ class StringTagFieldTest extends SapphireTest
         $this->assertNotEmpty($attributes['data-schema']);
     }
 
-    /**
-     * Ensure a source of tags matches the given string tag names
-     *
-     * @param array $expected
-     * @param DataList $actualSource
-     */
-    protected function compareTagLists(array $expected, DataList $actualSource)
+    public function testPerformReadonlyTransformation()
     {
-        $actual = array_keys($actualSource->map('ID', 'Title')->toArray());
-        sort($expected);
-        sort($actual);
+        $field = new StringTagField('Tags');
+        $field->setSource(['Test1', 'Test2', 'Test3']);
 
-        $this->assertEquals(
-            $expected,
-            $actual
-        );
+        // Ensure a single value can be rendered
+        $field->setValue(['Test2']);
+        $field_readonly = $field->performReadonlyTransformation();
+        $this->assertEquals('Test2', $field_readonly->Value());
+
+        // Ensure multiple valid values are rendered
+        $field->setValue(['Test1', 'Test2']);
+        $field_readonly = $field->performReadonlyTransformation();
+        $this->assertEquals('Test1, Test2', $field_readonly->Value());
+
+        // Ensure an value not in the source array is still rendered
+        // (because e.g. in history view it must have been a valid value when it was set)
+        $field->setValue(['Test', 'Test1']);
+        $field_readonly = $field->performReadonlyTransformation();
+        $this->assertEquals('Test, Test1', $field_readonly->Value());
     }
 
     /**


### PR DESCRIPTION
An archived page with defined tags using StringTagField cannot be displayed.

```php
class Page extends SiteTree
{
  private static $db = [
    'Tags' => 'Text'
  ];

  public function getCMSFields()
  {
    $fields = parent::getCMSFields();
    $tagField = StringTagField::create('Tags', 'Tags')->setCanCreate(true);
    $fields->addFieldToTab('Root.Main', $tagField, 'Content');
    return $fields;
  }
}
```
```
[Emergency] Uncaught TypeError: array_key_exists(): Argument #1 ($key) must be a valid array offset type
GET /admin/pages/edit/show/3

Line 32 in /var/www/html/vendor/silverstripe/framework/src/Forms/SingleLookupField.php
```

```
23     /**
24      * @return mixed|null
25      */
26     protected function valueToLabel()
27     {
28         $value = $this->value;
29         $source = $this->getSource();
30         $source = ($source instanceof Map) ? $source->toArray() : $source;
31 
32         if (array_key_exists($value, $source ?? [])) {
33             return $source[$value];
34         }
35 
36         return null;
37     }
38
```

Adding this code to silverstripe/tagfield/src/StringTagField.php solves the problem...

```php
class StringTagField extends DropdownField
{
...
  public function performReadonlyTransformation()
  {
    /** @var ReadonlyField $copy */
    $copy = $this->castedCopy(ReadonlyField::class);
    $copy->setValue(implode(', ', $this->Value()));

    return $copy;
  }
...
}
```