### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.13",
         "silverstripe/versioned": "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::withNoReplacement() on --prefer-lowest build

https://github.com/silverstripe/silverstripe-tagfield/actions/runs/9851673046