### PR TITLE
DEP Limit PHP support for CMS 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "issues": "http://github.com/silverstripe/silverstripe-tagfield/issues"
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "silverstripe/framework": "^6",
         "silverstripe/versioned": "^3"
     },


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/.github/issues/297