### PR TITLE
ENH Refactor the way selected options are returned for read only tag fields

### DIFF
--- a/src/ReadonlyTagField.php
+++ b/src/ReadonlyTagField.php
@@ -27,7 +27,8 @@ class ReadonlyTagField extends TagField
     {
         $options = array();
 
-        foreach ($this->getOptions()->filter('Selected', true) as $option) {
+        // only get the selected options
+        foreach ($this->getOptions(true) as $option) {
             $options[] = $option->Title;
         }
 

--- a/tests/TagFieldTest.php
+++ b/tests/TagFieldTest.php
@@ -408,6 +408,22 @@ class TagFieldTest extends SapphireTest
         $field->setTitleField('Name');
         $readOnlyField = $field->performReadonlyTransformation();
         $this->assertEquals('Name', $readOnlyField->getTitleField());
+
+        // Also check Field options
+        $field = new TagField('Tags', '', TagFieldTestBlogTag::get());
+        $field->setTitleField('Title');
+        $field->setValue(['Tag1']);
+
+        // When not read only (and not lazy-loading) all source options are returned
+        $htmlText = $field->Field();
+        $this->assertStringContainsString('Tag1', $htmlText);
+        $this->assertStringContainsString('222', $htmlText);
+
+        // When read only mode, only selected options are returned
+        $readOnlyField = $field->performReadonlyTransformation();
+        $htmlText = $readOnlyField->Field();
+        $this->assertStringContainsString('Tag1', $htmlText);
+        $this->assertStringNotContainsString('222', $htmlText);
     }
 
     public function testItDisplaysWithSelectedValuesFromDataList()


### PR DESCRIPTION
## Description
When transforming a tag field to read only mode and calling the `Field` method on it for rendering, it was observed that all options in the tag field source were being returned from the database, and iterated to provide a full list on which the selected options are then filtered. Where there are large numbers of items in the source this was causing performance issues.

The `getOptions` method that is called for setting the values on the read only tag field accepts a `$onlySelected` parameter  which, when set to `true`, will avoid the loading of all options, and instead just return the selected values. Calling the getOptions method in this way means that we no longer need the filtering within the `ReadonlyTagField` class.

## Manual testing steps
These steps are included on issue #309 

## Issues
- #309 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
