### PR TITLE
FIX Avoid infinite recursive loop with attributes in schemadata

### DIFF
--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -198,19 +198,6 @@ class StringTagField extends DropdownField
     }
 
     /**
-     * When not used in a React form factory context, this adds the schema data to SilverStripe template
-     * rendered attributes lists
-     *
-     * @return array
-     */
-    public function getAttributes()
-    {
-        $attributes = parent::getAttributes();
-        $attributes['data-schema'] = json_encode($this->getSchemaData());
-        return $attributes;
-    }
-
-    /**
      * @return string
      */
     protected function getSuggestURL()

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -381,7 +381,6 @@ class TagField extends MultiSelectField
             [
                 'name' => $name,
                 'style' => 'width: 100%',
-                'data-schema' => json_encode($this->getSchemaData()),
             ]
         );
     }

--- a/templates/SilverStripe/TagField/TagField.ss
+++ b/templates/SilverStripe/TagField/TagField.ss
@@ -1,1 +1,1 @@
-<div $AttributesHTML></div>
+<div $AttributesHTML $SchemaAttributesHtml></div>

--- a/tests/StringTagFieldTest.php
+++ b/tests/StringTagFieldTest.php
@@ -132,13 +132,6 @@ class StringTagFieldTest extends SapphireTest
         $this->assertStringContainsString('suggest', $schema['optionUrl']);
     }
 
-    public function testSchemaIsAddedToAttributes()
-    {
-        $field = new StringTagField('TestField');
-        $attributes = $field->getAttributes();
-        $this->assertNotEmpty($attributes['data-schema']);
-    }
-
     public function testPerformReadonlyTransformation()
     {
         $field = new StringTagField('Tags');

--- a/tests/TagFieldTest.php
+++ b/tests/TagFieldTest.php
@@ -413,6 +413,8 @@ class TagFieldTest extends SapphireTest
         $field = new TagField('Tags', '', TagFieldTestBlogTag::get());
         $field->setTitleField('Title');
         $field->setValue(['Tag1']);
+        $form = new Form();
+        $field->setForm($form);
 
         // When not read only (and not lazy-loading) all source options are returned
         $htmlText = $field->Field();
@@ -480,13 +482,6 @@ class TagFieldTest extends SapphireTest
         $this->assertTrue($schema['lazyLoad']);
         $this->assertTrue($schema['creatable']);
         $this->assertStringContainsString('suggest', $schema['optionUrl']);
-    }
-
-    public function testSchemaIsAddedToAttributes()
-    {
-        $field = new TagField('TestField');
-        $attributes = $field->getAttributes();
-        $this->assertNotEmpty($attributes['data-schema']);
     }
 
     /**


### PR DESCRIPTION
Reflects changes in https://github.com/silverstripe/silverstripe-framework/pull/11469 - that may need to be merged for CI to go green.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/9124