### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/versioned": "^3"
     },
     "require-dev": {

--- a/tests/TagFieldTest.php
+++ b/tests/TagFieldTest.php
@@ -358,7 +358,7 @@ class TagFieldTest extends SapphireTest
         /**
          * @var TagFieldTestBlogPost $record
          */
-        $record = DataObject::get_by_id(TagFieldTestBlogPost::class, $record->ID);
+        $record = TagFieldTestBlogPost::get()->byID($record->ID);
 
         $this->compareExpectedAndActualTags(
             ['Tag1'],


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
