### PR TITLE
ENH Optimise SQL queries to improve performance

### DIFF
--- a/src/TagField.php
+++ b/src/TagField.php
@@ -319,7 +319,7 @@ class TagField extends MultiSelectField
             $options->push(ArrayData::create([
                 'Title' => $option,
                 'Value' => $option,
-                'Selected' => (bool) $values->find($titleField, $option)
+                'Selected' => $values->filter($titleField, $option)->exists()
             ]));
         };
 


### PR DESCRIPTION
While not reducing the _number_ of queries, I've updated a bunch of calls to `find()` and `byID()` (which were only being used to check if a record exists) to instead use `filter()->exists()` which is more efficient.

## Issue

- https://github.com/silverstripe/.github/issues/416